### PR TITLE
feat: support SEP-07 callbacks

### DIFF
--- a/i18n/locales/en/generic.json
+++ b/i18n/locales/en/generic.json
@@ -41,6 +41,7 @@
     "stellar-address-not-found-error": "Stellar address not found: {{address}}",
     "stellar-address-request-failed-error": "Stellar address resolution of {{address}} failed.",
     "stellar-uri-verification-error": "Stellar URI's signature could not be verified.",
+    "stellar-uri-callback-format-error": "Stellar URI's callback is not valid: {{reason}}",
     "submission-failed-error": "Submitting transaction to {{endpoint}} failed with status {{status}}: {{message}}",
     "testnet-endpoint-not-available-error": "{{service}} does not provide a testnet endpoint.",
     "timeout-error": "Request timed out",

--- a/i18n/locales/es/generic.json
+++ b/i18n/locales/es/generic.json
@@ -36,6 +36,7 @@
     "stellar-address-not-found-error": "Dirección Stellar no encontrada: {{address}}",
     "stellar-address-request-failed-error": "Falló la resolución de la dirección Stellar {{address}}",
     "stellar-uri-verification-error": "No se ha podido verificar la firma de Stellar URI",
+    "stellar-uri-callback-format-error": "Stellar URI's callback is not valid: {{reason}}",
     "submission-failed-error": "Envío de transacción a {{endpoint}} falló con estado {{status}}: {{message}}",
     "testnet-endpoint-not-available-error": "{{service}} no provee un punto de conexión Testnet.",
     "timeout-error": "Solicitud ha caducado",

--- a/i18n/locales/it/generic.json
+++ b/i18n/locales/it/generic.json
@@ -32,6 +32,7 @@
     "stellar-address-not-found-error": "Indirizzo stellare non trovato: {{address}}",
     "stellar-address-request-failed-error": "Risoluzione stellare dell'indirizzo di {{address}} non riuscita.",
     "stellar-uri-verification-error": "Non è stato possibile verificare la firma di Stellar URI.",
+    "stellar-uri-callback-format-error": "Stellar URI's callback is not valid: {{reason}}",
     "submission-failed-error": "Invio della transazione a {{endpoint}} fallita {{status}}: {{message}}",
     "testnet-endpoint-not-available-error": "{{service}} non fornisce un endpoint testnet.",
     "timeout-error": "Richiesta scaduta",

--- a/i18n/locales/ru/generic.json
+++ b/i18n/locales/ru/generic.json
@@ -41,6 +41,7 @@
     "stellar-address-not-found-error": "Адрес Stellar не найден: {{address}}",
     "stellar-address-request-failed-error": "Не удалось найти адрес Stellar {{address}}.",
     "stellar-uri-verification-error": "Не удалось верифицировать Stellar URI.",
+    "stellar-uri-callback-format-error": "Проблема с параметром callback: {{reason}}",
     "submission-failed-error": "Не удалось отправить транзакцию на {{endpoint}} с ошибкой статуса {{status}}: {{message}}",
     "testnet-endpoint-not-available-error": "{{service}} не предоставляет конечную точку тестовой сети.",
     "timeout-error": "Время запроса истекло",

--- a/src/App/css/base-styles.css
+++ b/src/App/css/base-styles.css
@@ -17,7 +17,7 @@ body {
 }
 
 .android-top-spacing {
-  padding-top: 28px;
+  padding-top: 32px;
 }
 
 .iphone-notch-top-spacing {

--- a/src/Generic/lib/errors.ts
+++ b/src/Generic/lib/errors.ts
@@ -101,8 +101,12 @@ export function getErrorTranslation(error: Error, t: TFunction): string {
     prefix += ": "
   }
 
-  const fallback = error.message
-  return prefix + t([key, fallback], params)
+  const fallback = (error.message as any)?.message || error.message
+  try {
+    return prefix + t([key, fallback], params)
+  } catch (e) {
+    return prefix + fallback
+  }
 }
 
 export function renderFormFieldError(error: any, t: TFunction) {

--- a/src/Generic/lib/multisig-service.ts
+++ b/src/Generic/lib/multisig-service.ts
@@ -26,6 +26,7 @@ export interface MultisigTransactionResponse {
   signed_by: string[]
   signers: string[]
   updated_at: string
+  external?: boolean
 }
 
 export interface SignatureRequestSigner {

--- a/src/Payment/components/PaymentDialog.tsx
+++ b/src/Payment/components/PaymentDialog.tsx
@@ -14,6 +14,7 @@ import ScrollableBalances from "~Generic/components/ScrollableBalances"
 import MainTitle from "~Generic/components/MainTitle"
 import TransactionSender from "~Transaction/components/TransactionSender"
 import PaymentForm from "./PaymentForm"
+import { MultisigTransactionResponse } from "~Generic/lib/multisig-service"
 
 interface Props {
   account: Account
@@ -21,7 +22,7 @@ interface Props {
   horizon: Server
   onClose: () => void
   openOrdersCount: number
-  sendTransaction: (transaction: Transaction) => Promise<any>
+  sendTransaction: (transaction: Transaction, signatureRequest?: MultisigTransactionResponse) => Promise<any>
 }
 
 function PaymentDialog(props: Props) {
@@ -31,12 +32,17 @@ function PaymentDialog(props: Props) {
   const [txCreationPending, setTxCreationPending] = React.useState(false)
 
   const handleSubmit = React.useCallback(
-    async (createTx: (horizon: Server, account: Account) => Promise<Transaction>) => {
+    async (
+      createTx: (
+        horizon: Server,
+        account: Account
+      ) => Promise<{ tx: Transaction; signatureRequest?: MultisigTransactionResponse }>
+    ) => {
       try {
         setTxCreationPending(true)
-        const tx = await createTx(props.horizon, props.account)
+        const { tx, signatureRequest } = await createTx(props.horizon, props.account)
         setTxCreationPending(false)
-        await sendTransaction(tx)
+        await sendTransaction(tx, signatureRequest)
       } catch (error) {
         trackError(error)
       } finally {

--- a/src/Transaction/components/TransactionSender.tsx
+++ b/src/Transaction/components/TransactionSender.tsx
@@ -225,7 +225,8 @@ class TransactionSender extends React.Component<Props, State> {
         await this.submitTransactionToThirdPartyService(signedTx, thirdPartySecurityService)
       } else if (
         this.state.signatureRequest &&
-        (this.state.signatureRequest.status === "ready" || this.state.signatureRequest.status === "failed")
+        (this.state.signatureRequest.status === "ready" || this.state.signatureRequest.status === "failed") &&
+        !this.state.signatureRequest.external // do not submit SEP-07 signed txs via backend
       ) {
         await this.submitMultisigTransactionToStellarNetwork(this.state.signatureRequest)
       } else if (
@@ -236,7 +237,8 @@ class TransactionSender extends React.Component<Props, State> {
         (await requiresRemoteSignatures(horizon, signedTx, account.publicKey))
       ) {
         await this.submitTransactionToMultisigService(signedTx, unsignedTx)
-      } else {
+      } else if (!this.state.signatureRequest || !this.state.signatureRequest.external) {
+        // skip submission for SEP-07 links with callback
         await this.submitTransactionToHorizon(signedTx)
       }
       setTimeout(() => {

--- a/src/Transaction/lib/stellar-uri.ts
+++ b/src/Transaction/lib/stellar-uri.ts
@@ -18,5 +18,19 @@ export async function verifyTransactionRequest(request: string, options: Verific
     }
   }
 
+  if (parsedURI.callback) {
+    try {
+      const callbackURI = new URL(parsedURI.callback)
+      if (!["http:", "https:"].includes(callbackURI.protocol)) {
+        throw new Error("Unsupported schema")
+      }
+    } catch (e) {
+      throw CustomError(
+        "StellarUriVerificationError",
+        i18next.t("stellar-uri-callback-format-error", { reason: e.message || "" })
+      )
+    }
+  }
+
   return parsedURI
 }

--- a/src/TransactionRequest/components/PaymentRequestContent.tsx
+++ b/src/TransactionRequest/components/PaymentRequestContent.tsx
@@ -15,6 +15,7 @@ import { getAssetsFromBalances } from "~Generic/lib/stellar"
 import { PaymentParams } from "~Payment/components/PaymentForm"
 import PaymentForm from "~Payment/components/PaymentForm"
 import { SendTransaction } from "../../Transaction/components/TransactionSender"
+import { MultisigTransactionResponse } from "~Generic/lib/multisig-service"
 
 interface ConnectedPaymentFormProps {
   accountData: AccountData
@@ -37,12 +38,17 @@ function ConnectedPaymentForm(props: ConnectedPaymentFormProps) {
   ])
 
   const handleSubmit = React.useCallback(
-    async (createTx: (horizon: Server, account: Account) => Promise<Transaction>) => {
+    async (
+      createTx: (
+        horizon: Server,
+        account: Account
+      ) => Promise<{ tx: Transaction; signatureRequest?: MultisigTransactionResponse }>
+    ) => {
       try {
         setTxCreationPending(true)
-        const tx = await createTx(props.horizon, props.selectedAccount)
+        const { tx, signatureRequest } = await createTx(props.horizon, props.selectedAccount)
         setTxCreationPending(false)
-        await sendTransaction(tx)
+        await sendTransaction(tx, signatureRequest)
       } catch (error) {
         trackError(error)
       } finally {
@@ -107,9 +113,10 @@ function PaymentRequestContent(props: PaymentRequestContentProps) {
       asset,
       destination,
       memo,
-      memoType
+      memoType,
+      payStellarUri: props.payStellarUri
     }
-  }, [amount, asset, destination, memo, memoType])
+  }, [amount, asset, destination, memo, memoType, props.payStellarUri])
 
   return (
     <Box>

--- a/src/TransactionRequest/components/StellarRequestReviewDialog.tsx
+++ b/src/TransactionRequest/components/StellarRequestReviewDialog.tsx
@@ -51,7 +51,6 @@ function StellarRequestReviewDialog(props: StellarRequestReviewDialogProps) {
 
   return (
     <DialogBody
-      preventNotchSpacing
       top={<MainTitle hideBackButton onBack={onClose} title={t("transaction-request.stellar-uri.title")} />}
       actions={props.actionsRef}
     >

--- a/src/TransactionRequest/components/TransactionRequestContent.tsx
+++ b/src/TransactionRequest/components/TransactionRequestContent.tsx
@@ -166,8 +166,7 @@ function TransactionRequestContent(props: TransactionRequestContentProps) {
     <Box>
       {msg && (
         <Typography>
-          <b>{t("transaction-request.transaction.uri-content.message")}:</b>
-          {msg}
+          <b>{t("transaction-request.transaction.uri-content.message")}:</b> {msg}
         </Typography>
       )}
       <Typography className={classes.uriContainer} variant="h6">

--- a/src/TransactionRequest/components/TransactionRequestContent.tsx
+++ b/src/TransactionRequest/components/TransactionRequestContent.tsx
@@ -17,6 +17,7 @@ import { RefStateObject } from "~Generic/hooks/userinterface"
 import { useTransactionTitle } from "~TransactionReview/components/TransactionReviewDialog"
 import TransactionSummary from "~TransactionReview/components/TransactionSummary"
 import { SendTransaction } from "../../Transaction/components/TransactionSender"
+import { MultisigTransactionStatus } from "~Generic/lib/multisig-service"
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -106,7 +107,26 @@ function TransactionRequestContent(props: TransactionRequestContentProps) {
         Object.keys(filledReplacements).length > 0
           ? props.txStellarUri.replace(filledReplacements).getTransaction()
           : props.txStellarUri.getTransaction()
-      sendTransaction(newTx)
+
+      // if the link has callback, create a signatureRequest so that it goes via multisig flow
+      // multisig flow skips submission to the network now and that's what we want for SEP07 links with callbacks
+      if (props.txStellarUri.callback) {
+        const signatureRequest = {
+          created_at: Date.now().toString(),
+          cursor: "",
+          hash: props.txStellarUri.getTransaction().toXDR(),
+          req: props.txStellarUri.toString(),
+          status: MultisigTransactionStatus.pending,
+          signed_by: [],
+          signers: [],
+          updated_at: Date.now().toString(),
+          external: true
+        }
+
+        sendTransaction(newTx, signatureRequest)
+      } else {
+        sendTransaction(newTx)
+      }
     } catch (error) {
       trackError(error)
     } finally {
@@ -146,7 +166,7 @@ function TransactionRequestContent(props: TransactionRequestContentProps) {
     <Box>
       {msg && (
         <Typography>
-          <b>{t("transaciton-request.transaction.uri-content.message")}:</b>
+          <b>{t("transaction-request.transaction.uri-content.message")}:</b>
           {msg}
         </Typography>
       )}

--- a/src/TransactionRequest/components/VerifyTrustedServiceDialog.tsx
+++ b/src/TransactionRequest/components/VerifyTrustedServiceDialog.tsx
@@ -23,7 +23,6 @@ function VerifyTrustedServiceDialog(props: VerifyTrustedServiceDialogProps) {
   return (
     <DialogBody
       background={<WarnIcon style={{ fontSize: 220 }} />}
-      preventNotchSpacing
       top={<MainTitle hideBackButton onBack={onCancel} title={t("transaction-request.verify-trusted-service.title")} />}
       actions={
         <DialogActionsBox desktopStyle={{ marginTop: 32 }} smallDialog>

--- a/src/Workers/net-worker/multisig.ts
+++ b/src/Workers/net-worker/multisig.ts
@@ -235,7 +235,8 @@ export async function submitSignature(multisigTx: MultisigTransactionResponse, s
     await handleServerError(response, responseData)
   }
 
-  if (responseData.status === "ready") {
+  if (responseData.status === "ready" && !multisigTx.external) {
+    // skip submission for SEP-07 txs
     // Transaction is now sufficiently signed to be submitted to the Stellar network
     const txSubmissionResponse = await submitMultisigTransactionToStellarNetwork(multisigTx)
 
@@ -309,10 +310,10 @@ async function handleServerError(response: Response, responseBodyObject: any) {
   } else {
     throw CustomError(
       "SubmissionFailedError",
-      `Submitting transaction to multi-signature service failed  ${response.status}: ${message}`,
+      `Submitting transaction to multi-signature service failed  ${response.status}: ${message.message || message}`,
       {
         endpoint: "multi-signature service",
-        message,
+        message: message.message || message,
         status: String(response.status)
       }
     )


### PR DESCRIPTION
using existing multisig code as much as possible, so when wallet recieves SEP-07 requests with callback it stores a new signatureRequest to activate multisig flow (even if there is just one signature).

When callback is provided the wallet won't publish the tx to the network (according to SEP07 spec).

Different cases handled by different parts of the code (Solar's design):
1. opening web+stellar:tx link by click or QR code scan
2. opening web+stellar:pay link by click or QR code scan
3. opening web+stellar:pay link from Payment Dialog using camera scanner

Closes #87 