### PR TITLE
fix: missing memo on SEP07 payment txs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@stellar/stellar-sdk": "^13.1.0",
         "@suncewallet/stellar-sep-10": "^1.0.0",
         "@suncewallet/stellar-transfer": "^1.0.0",
-        "@suncewallet/stellar-uri": "^1.0.0",
+        "@suncewallet/stellar-uri": "^1.1.0",
         "big.js": "^5.2.2",
         "core-js": "^3.41.0",
         "electron-context-menu": "^3.6.1",
@@ -5548,9 +5548,9 @@
       }
     },
     "node_modules/@suncewallet/stellar-uri": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@suncewallet/stellar-uri/-/stellar-uri-1.0.0.tgz",
-      "integrity": "sha512-OncepZYohXJlUCv/1f8rOpuHLmkJbKi10PMBUM2pVWESCAMzS/3KFgGQhjLLmHBj6kOHxf1z7DpJPduZbc0yLw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@suncewallet/stellar-uri/-/stellar-uri-1.1.0.tgz",
+      "integrity": "sha512-lmu77Blnj1xq/v51EHM4K3BPNxBO9RcITBKevWpd3n5NgcBd7cDNCpl+7/4IIEywYZkOd8H+dscqK/xqAYVMPg==",
       "license": "MIT",
       "dependencies": {
         "@suncewallet/txrep": "^1.0.0"
@@ -8165,6 +8165,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
       "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@stellar/stellar-sdk": "^13.1.0",
     "@suncewallet/stellar-sep-10": "^1.0.0",
     "@suncewallet/stellar-transfer": "^1.0.0",
-    "@suncewallet/stellar-uri": "^1.0.0",
+    "@suncewallet/stellar-uri": "^1.1.0",
     "big.js": "^5.2.2",
     "core-js": "^3.41.0",
     "electron-context-menu": "^3.6.1",


### PR DESCRIPTION
Reason: @stellarguard/stellar-uri blindy casts memo_type parameter in the link to MemoType from stellar-sdk. However, SEP07 memo_type is a string starting with MEMO_ (e.g. MEMO_TEXT), while MemoType is defined as type MemoType = 'none' | 'id' | 'text' | 'hash' | 'return'. Thus the parsed uri contains MEMO_TEXT memoType attribute which Sunce (and @stellar/stellar-sdk) doesn't understand.

Solution is to converge memoType to proper value on the stellar-uri library side. Done here: https://github.com/SunceWallet/stellar-uri/pull/1

Supersedes: #104 