### PR TITLE
fix: `n.sequence.add` is not a function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@stellar/stellar-sdk": "^13.1.0",
         "@suncewallet/stellar-sep-10": "^1.0.0",
         "@suncewallet/stellar-transfer": "^1.0.0",
-        "@suncewallet/stellar-uri": "^1.1.0",
+        "@suncewallet/stellar-uri": "^1.1.2",
         "big.js": "^5.2.2",
         "core-js": "^3.41.0",
         "electron-context-menu": "^3.6.1",
@@ -4029,15 +4029,6 @@
         "sodium-native": "^4.3.0"
       }
     },
-    "node_modules/@stellar/stellar-base/node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@stellar/stellar-base/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -4086,15 +4077,6 @@
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
-      }
-    },
-    "node_modules/@stellar/stellar-sdk/node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@stellar/stellar-sdk/node_modules/eventsource": {
@@ -5548,12 +5530,12 @@
       }
     },
     "node_modules/@suncewallet/stellar-uri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@suncewallet/stellar-uri/-/stellar-uri-1.1.0.tgz",
-      "integrity": "sha512-lmu77Blnj1xq/v51EHM4K3BPNxBO9RcITBKevWpd3n5NgcBd7cDNCpl+7/4IIEywYZkOd8H+dscqK/xqAYVMPg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@suncewallet/stellar-uri/-/stellar-uri-1.1.2.tgz",
+      "integrity": "sha512-pJqyVV+HSycQt4TAFn+Qceh78E3flWvxucFN8fEm6CLSruXkrndrH3Fu3HR/t+hjY+gDaE/0F/FamFyFM03PQQ==",
       "license": "MIT",
       "dependencies": {
-        "@suncewallet/txrep": "^1.0.0"
+        "@suncewallet/txrep": "^1.0.2"
       },
       "engines": {
         "node": ">=10"
@@ -5563,12 +5545,12 @@
       }
     },
     "node_modules/@suncewallet/txrep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@suncewallet/txrep/-/txrep-1.0.0.tgz",
-      "integrity": "sha512-xo/J5xSS0GdpALohMDoWkQjOHpQuuASoM0ToQ8/bqX6VgdQoBLoM/LE10Da7YQqwjSTr6tYlOgA3Z1+xeBC7Pw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@suncewallet/txrep/-/txrep-1.0.2.tgz",
+      "integrity": "sha512-VSbpALG6oRQqY5KH0tGxzCfD0k0ULCHiUizRYkExpikx84udjFWvDWF81Te+top4KR0pQc41JAtktUN5OydtBQ==",
       "license": "MIT",
       "dependencies": {
-        "bignumber.js": "^4.0.0"
+        "bignumber.js": "^9.1.2"
       },
       "engines": {
         "node": ">=8.9"
@@ -8162,9 +8144,9 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "license": "MIT",
       "engines": {
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@stellar/stellar-sdk": "^13.1.0",
     "@suncewallet/stellar-sep-10": "^1.0.0",
     "@suncewallet/stellar-transfer": "^1.0.0",
-    "@suncewallet/stellar-uri": "^1.1.0",
+    "@suncewallet/stellar-uri": "^1.1.2",
     "big.js": "^5.2.2",
     "core-js": "^3.41.0",
     "electron-context-menu": "^3.6.1",


### PR DESCRIPTION
Reason: `@suncewallet/txrep` was updated to use latest `@stellar/stellar-sdk@13` which is using BigNumber.js@9.1.2. The `@suncewallet/txrep` itself was using `BigNumber.js@4` as direct dependency (probably the same version was used by `stellar-sdk@9`).

`BigNumber.js@9` had breaking changes in API, namely remove `all`, `sub` and `mul` aliases and removed `floor` method. Typescript check failed to find this issues because the check was done against directly imported `BigNumber.js@4`.

Fixed in `@suncewallet/txrep@1.0.2` here: https://github.com/SunceWallet/txrep/commit/7f696635c7c7d0be14a087f5b7a0d47f2db35128

Closes #110 