### PR TITLE
fix: make infinity sign for own assets larger. Just for looks

### DIFF
--- a/src/Account/components/AccountBalances.tsx
+++ b/src/Account/components/AccountBalances.tsx
@@ -38,7 +38,7 @@ export const SingleBalance = React.memo(function SingleBalance(props: SingleBala
           {integerPart}
           <span style={{ opacity: 0.8 }}>{decimalPart ? "." + decimalPart : ""}</span>
         </span>}
-        {props.showInfinity &&<span style={{ display: "inline-block", fontWeight: 300 }}>∞</span>}
+        {props.showInfinity &&<span style={{ display: "inline-block", fontWeight: 300, transform: "scale(1.5)" }}>∞</span>}
       </span>
       {props.assetCode ? (
         <>


### PR DESCRIPTION
Before:
<img width="292" alt="image" src="https://github.com/user-attachments/assets/97655d38-999d-4582-b42b-a664153379de" />

After:
<img width="305" alt="image" src="https://github.com/user-attachments/assets/53f5c66f-1c50-42cb-94d9-64b7bd42925a" />

Before:
<img width="598" alt="image" src="https://github.com/user-attachments/assets/fae9e17f-1068-407b-9afe-818f5a92253a" />

After:
<img width="588" alt="image" src="https://github.com/user-attachments/assets/3007ed63-de01-485c-b42b-6240d8255011" />

Before:
<img width="735" alt="image" src="https://github.com/user-attachments/assets/d0329e66-5c50-4c22-9c00-484377a32e3b" />

After:
<img width="754" alt="image" src="https://github.com/user-attachments/assets/5dd40edd-8554-45ac-b326-4ec5fe55e668" />

