### PR TITLE
fix: show operation name without uppercasing

### DIFF
--- a/src/TransactionReview/components/SummaryItem.tsx
+++ b/src/TransactionReview/components/SummaryItem.tsx
@@ -36,7 +36,8 @@ export const SummaryDetailsField = React.memo(function SummaryDetailsField(props
       }}
       InputLabelProps={{
         style: {
-          whiteSpace: "nowrap"
+          whiteSpace: "nowrap",
+          textTransform: "none",
         }
       }}
     />


### PR DESCRIPTION
MUI uppercases text fields by default. We are using those in readonly mode to show tx operations. However, account data entries are case sensitive, so let's disable uppercasing to preserve original capitalization


![telegram-cloud-photo-size-4-5960987408382149774-y](https://github.com/user-attachments/assets/84f48ca2-2f33-47fb-962f-41059ffb0a66)

https://t.me/c/2011632833/2481