### PR TITLE
feat: allow sending from Asset details page

### DIFF
--- a/src/Account/components/AccountView.tsx
+++ b/src/Account/components/AccountView.tsx
@@ -26,7 +26,7 @@ import { warningColor, FullscreenDialogTransition } from "~App/theme"
 import { useLiveAccountData } from "~Generic/hooks/stellar-subscriptions"
 import { useClipboard, useIsMobile, useRouter } from "~Generic/hooks/userinterface"
 import { getLastArgumentFromURL } from "~Generic/lib/url"
-import { matchesRoute } from "~Generic/lib/routes"
+import { matchesRoute, matchesRouteWithParams } from "~Generic/lib/routes"
 import { InlineErrorBoundary, HideOnError } from "~Generic/components/ErrorBoundaries"
 import { DialogsContext } from "~App/contexts/dialogs"
 
@@ -136,7 +136,7 @@ const AccountPageContent = React.memo(function AccountPageContent(props: Account
     !matchesRoute(router.location.pathname, routes.manageAccountAssets("*"))
   const showAssetTrading = matchesRoute(router.location.pathname, routes.tradeAsset("*"))
   const showBalanceDetails = matchesRoute(router.location.pathname, routes.balanceDetails("*"))
-  const showCreatePayment = matchesRoute(router.location.pathname, routes.createPayment("*"))
+  const showCreatePayment = matchesRouteWithParams(router.location.pathname, routes.createPayment(":accountId", ":assetId?"))
   const showDeposit = matchesRoute(router.location.pathname, routes.depositAsset("*"))
   const showLumenPurchase = matchesRoute(router.location.pathname, routes.purchaseLumens("*"))
   const showReceivePayment = matchesRoute(router.location.pathname, routes.receivePayment("*"))
@@ -415,13 +415,13 @@ const AccountPageContent = React.memo(function AccountPageContent(props: Account
             </React.Suspense>
           </Dialog>
           <Dialog
-            open={showCreatePayment}
+            open={!!showCreatePayment}
             fullScreen
             onClose={closeDialog}
             TransitionComponent={FullscreenDialogTransition}
           >
             <React.Suspense fallback={<ViewLoading />}>
-              <PaymentDialog account={props.account} onClose={closeDialog} />
+              <PaymentDialog account={props.account} assetId={showCreatePayment?.assetId} onClose={closeDialog} />
             </React.Suspense>
           </Dialog>
           <Dialog

--- a/src/App/routes.ts
+++ b/src/App/routes.ts
@@ -7,7 +7,7 @@ export const assetDetails = (accountID: string, assetID: string) => `/account/${
 export const balanceDetails = (accountID: string) => `/account/${accountID}/balances`
 export const changeAccountPassword = (accountID: string) => `/account/${accountID}/settings/password`
 export const createAccount = (testnet: boolean) => `/account/create/${testnet ? "testnet" : "mainnet"}`
-export const createPayment = (accountID: string) => `/account/${accountID}/send`
+export const createPayment = (accountID: string, preselectedAsset?: string) => `/account/${accountID}/send${preselectedAsset ? `/${preselectedAsset}` : ''}`
 export const deleteAccount = (accountID: string) => `/account/${accountID}/settings/delete`
 export const depositAsset = (accountID: string) => `/account/${accountID}/deposit`
 export const exportSecretKey = (accountID: string) => `/account/${accountID}/settings/export`

--- a/src/Assets/components/AssetDetailsActions.tsx
+++ b/src/Assets/components/AssetDetailsActions.tsx
@@ -4,6 +4,7 @@ import { Asset, Operation, Horizon, Transaction } from "@stellar/stellar-sdk"
 import Dialog from "@material-ui/core/Dialog"
 import ClearIcon from "@material-ui/icons/Clear"
 import SwapHorizIcon from "@material-ui/icons/SwapHoriz"
+import SendIcon from "@material-ui/icons/Send"
 import { Account } from "~App/contexts/accounts"
 import { trackError } from "~App/contexts/notifications"
 import * as routes from "~App/routes"
@@ -41,7 +42,7 @@ function AssetDetailsActions(props: Props) {
   )
 
   const createAddAssetTransaction = async (options: { limit?: string } = {}) => {
-    const operations = [Operation.changeTrust({ asset, limit: options.limit, withMuxing: true })]
+    const operations = [Operation.changeTrust({ asset, limit: options.limit })]
     return createTransaction(operations, {
       accountData,
       horizon: props.horizon,
@@ -76,6 +77,11 @@ function AssetDetailsActions(props: Props) {
     [asset, props.account.id, router.history]
   )
 
+  const sendThisAsset = React.useCallback(
+    () => router.history.push(routes.createPayment(props.account.id, stringifyAsset(asset))),
+    [asset, props.account.id, router.history]
+  )
+
   return (
     <>
       <DialogActionsBox desktopStyle={dialogActionsBoxStyle} smallDialog>
@@ -86,6 +92,9 @@ function AssetDetailsActions(props: Props) {
             </ActionButton>
             <ActionButton icon={<SwapHorizIcon />} onClick={tradeThisAsset} type="primary">
               {t("account.add-asset.action.trade")}
+            </ActionButton>
+            <ActionButton icon={<SendIcon />} onClick={sendThisAsset} type="primary">
+              {t("account.action.send")}
             </ActionButton>
           </>
         ) : (

--- a/src/Generic/lib/routes.ts
+++ b/src/Generic/lib/routes.ts
@@ -32,3 +32,56 @@ export function matchesRoute(pathname: string, routepath: string, exactMatch?: b
 
   return true
 }
+
+/**
+ * @param pathname      Some actual path, like `router.location.pathname`.
+ * @param routepath     A route path, potentially with placeholders, like `/account/:id` or `/account/:id?`.
+ * @param [exactMatch]  Path must match route if set. Otherwise it's ok if the path starts with that route (prefix match).
+ * @returns Object with parameter values if match found, undefined otherwise
+ */
+export function matchesRouteWithParams(pathname: string, routepath: string, exactMatch?: boolean): Record<string, string> | undefined {
+  const pathFragments = normalizePath(pathname).split("/")
+  const routeFragments = normalizePath(routepath).split("/")
+  const params: Record<string, string> = {}
+
+  // Count required segments in routepath
+  const requiredSegments = routeFragments.filter(fragment => !fragment.endsWith("?")).length
+
+  // Check if we have enough path fragments
+  if (pathFragments.length < requiredSegments) {
+    return undefined
+  }
+
+  // For exact match, path length must match route length (accounting for optional segments)
+  if (exactMatch && pathFragments.length > routeFragments.length) {
+    return undefined
+  }
+
+  for (let index = 0; index < routeFragments.length; index++) {
+    const routeFragment = routeFragments[index]
+    const pathFragment = pathFragments[index]
+
+    // If we've run out of path fragments and the route fragment isn't optional, no match
+    if (pathFragment === undefined) {
+      if (!routeFragment.endsWith("?")) {
+        return undefined
+      }
+      continue
+    }
+
+    if (routeFragment === "*") {
+      continue
+    } else if (routeFragment.charAt(0) === ":") {
+      // Extract parameter name (removing the "?" if it's optional)
+      const paramName = routeFragment.endsWith("?")
+        ? routeFragment.slice(1, -1)
+        : routeFragment.slice(1)
+
+      params[paramName] = pathFragment
+    } else if (pathFragment !== routeFragment) {
+      return undefined
+    }
+  }
+
+  return params
+}

--- a/src/Payment/components/PaymentForm.tsx
+++ b/src/Payment/components/PaymentForm.tsx
@@ -78,6 +78,7 @@ interface PaymentFormProps {
   ) => void
   openOrdersCount: number
   preselectedParams?: PaymentParams
+  canChangePreselectedParams?: boolean
   testnet: boolean
   trustedAssets: Asset[]
   txCreationPending?: boolean
@@ -265,7 +266,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
     () => (
       <TextField
         autoFocus={import.meta.env.VITE_PLATFORM !== "ios"}
-        disabled={Boolean(preselectedParams?.destination)}
+        disabled={!props.canChangePreselectedParams}
         error={Boolean(form.errors.destination)}
         fullWidth
         inputProps={{
@@ -299,7 +300,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
           <AssetSelector
             assets={props.accountData.balances}
             disableUnderline
-            disabled={Boolean(preselectedParams?.asset)}
+            disabled={!props.canChangePreselectedParams}
             showXLM
             style={{ alignSelf: "center" }}
             testnet={props.testnet}
@@ -343,7 +344,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
     () => (
       <PriceInput
         assetCode={assetSelector}
-        disabled={Boolean(preselectedParams?.amount)}
+        disabled={!props.canChangePreselectedParams}
         error={Boolean(form.errors.amount)}
         inputRef={form.register({
           required: t<string>("payment.validation.no-price"),
@@ -380,7 +381,7 @@ const PaymentForm = React.memo(function PaymentForm(props: PaymentFormProps) {
   const memoInput = React.useMemo(
     () => (
       <TextField
-        disabled={Boolean(preselectedParams?.memo)}
+        disabled={!props.canChangePreselectedParams}
         error={Boolean(form.errors.memoValue)}
         inputProps={{ maxLength: 28 }}
         label={form.errors.memoValue ? form.errors.memoValue.message : memoMetadata.label}
@@ -481,6 +482,7 @@ interface Props {
   actionsRef: RefStateObject
   openOrdersCount: number
   preselectedParams?: PaymentParams
+  canChangePreselectedParams?: boolean
   testnet: boolean
   trustedAssets: Asset[]
   txCreationPending?: boolean


### PR DESCRIPTION
Show "Send" button on Asset Details page. Clicking it opens Payment Dialog with asset preselected. Preselected asset can be changed here

Closes #134 


https://github.com/user-attachments/assets/dd99e136-94f7-480a-ae25-50b039df0639

