### PR TITLE
fix: when checking if multisig tx is fully signed consider ops threshold

### DIFF
--- a/src/App/contexts/settings.tsx
+++ b/src/App/contexts/settings.tsx
@@ -63,7 +63,7 @@ const initialSettings: SettingsState = {
 
 const initialIgnoredSignatureRequests: string[] = []
 
-const multiSignatureCoordinator = import.meta.env.VITE_MULTISIG_SERVICE || "v1.multisig.satoshipay.io"
+const multiSignatureCoordinator = import.meta.env.VITE_MULTISIG_SERVICE || "v1.multisig.sunce.app"
 
 const SettingsContext = React.createContext<ContextType>({
   agreedToTermsAt: initialSettings.agreedToTermsAt,

--- a/src/Generic/lib/threshold.ts
+++ b/src/Generic/lib/threshold.ts
@@ -1,0 +1,84 @@
+import { Horizon, Operation, OperationType, Transaction } from '@stellar/stellar-sdk';
+
+export type ThresholdLevel = 'low' | 'med' | 'high';
+
+const thresholdMap: Record<OperationType, ThresholdLevel> = {
+  createAccount: 'med',
+  payment: 'med',
+  pathPaymentStrictReceive: 'med',
+  pathPaymentStrictSend: 'med',
+  manageSellOffer: 'med',
+  manageBuyOffer: 'med',
+  createPassiveSellOffer: 'med',
+  setOptions: 'high',
+  changeTrust: 'med',
+  allowTrust: 'low',
+  accountMerge: 'high',
+  inflation: 'low',
+  manageData: 'med',
+  bumpSequence: 'low',
+  createClaimableBalance: 'med',
+  claimClaimableBalance: 'low',
+  beginSponsoringFutureReserves: 'med',
+  endSponsoringFutureReserves: 'med',
+  revokeSponsorship: 'med',
+  clawback: 'med',
+  clawbackClaimableBalance: 'med',
+  setTrustLineFlags: 'low',
+  invokeHostFunction: 'med',
+  extendFootprintTtl: 'med',
+  restoreFootprint: 'med',
+  liquidityPoolDeposit: 'med',
+  liquidityPoolWithdraw: 'med',
+};
+
+const thresholdValues: Record<ThresholdLevel, number> = {
+  low: 1,
+  med: 2,
+  high: 3,
+};
+
+const reverseThresholdValues: Record<number, ThresholdLevel> = {
+  1: 'low',
+  2: 'med',
+  3: 'high',
+};
+
+function getAccountThreshold(account: Horizon.AccountResponse, threshold: ThresholdLevel): number {
+  switch (threshold) {
+    case 'low':
+      return account.thresholds.low_threshold
+    case 'med':
+      return account.thresholds.med_threshold
+    case 'high':
+      return account.thresholds.high_threshold
+    default:
+      return account.thresholds.high_threshold
+  }
+}
+
+/**
+ * Determines the highest threshold level required to authorize a Stellar transaction.
+ * @param tx A Stellar Transaction object.
+ * @returns 'low', 'med', or 'high'
+ */
+export function getRequiredThreshold(operations: Operation[]): ThresholdLevel {
+  let maxThresholdValue = 0;
+
+  for (const op of operations) {
+    const opType = op.type;
+    const level = thresholdMap[opType] || 'high'; // default to 'high' for unknown
+    const numericValue = thresholdValues[level];
+    maxThresholdValue = Math.max(maxThresholdValue, numericValue);
+  }
+
+  return reverseThresholdValues[maxThresholdValue] || 'high';
+}
+
+export function getAccountTransactionThreshold(sourceAccount: Horizon.AccountResponse, transaction: Transaction): number {
+  const sourceAccountOps = transaction.operations.filter(op => !op.source || op.source === sourceAccount.account_id)
+  const opsThreshold = getRequiredThreshold(sourceAccountOps)
+  const accountThreshold = getAccountThreshold(sourceAccount, opsThreshold)
+  return accountThreshold
+}
+


### PR DESCRIPTION
Instead of checking against hard coded threshold, we now determining the maximum threshold for tx's operations (e.g. 'med' for 'payment') and use the corresponding account threshold (e.g. 'med_threshold').

The same check is done on signature-coordinator side, however here we want to skip backend completely if multisig is sufficiently signed on creation.

Another part of the fix is done on the multisig backend's side here:
https://github.com/SunceWallet/signature-coordinator/pull/4

In that PR we are setting correct transaction threshold + checking if it was signed enough using the similar calculations like here.

Closes #106 
Related upstream issue: https://github.com/satoshipay/solar/issues/1276