### PR TITLE
fix: fav icon for asset is not visible on mobile for assets with long names

### DIFF
--- a/src/Assets/components/AssetDetailsDialog.tsx
+++ b/src/Assets/components/AssetDetailsDialog.tsx
@@ -17,7 +17,7 @@ import { SingleBalance } from "~Account/components/AccountBalances"
 import DialogBody from "~Layout/components/DialogBody"
 import { AccountName } from "~Generic/components/Fetchers"
 import { ReadOnlyTextfield } from "~Generic/components/FormFields"
-import { VerticalLayout } from "~Layout/components/Box"
+import { Box, VerticalLayout } from "~Layout/components/Box"
 import MainTitle from "~Generic/components/MainTitle"
 import AssetDetailsActions from "./AssetDetailsActions"
 import AssetLogo from "./AssetLogo"
@@ -321,6 +321,9 @@ const useAssetDetailStyles = makeStyles({
     [breakpoints.down(600)]: {
       marginLeft: 39
     }
+  },
+  toolbar: {
+    marginLeft: "-4px"
   }
 })
 
@@ -362,14 +365,10 @@ function AssetDetailsDialog(props: Props) {
               asset.isNative()
                 ? "Stellar Lumens (XLM)"
                 : (<>
-                    {metadata && metadata.name
-                      ? `${metadata.name} (${asset.getCode()})`
-                      : asset.getCode()}
-                    <VisibilityIconButton
-                      accountId={props.account.accountID}
-                      asset={asset}
-                    />
-                  </>
+                  {metadata && metadata.name
+                    ? `${metadata.name} (${asset.getCode()})`
+                    : asset.getCode()}
+                </>
                 )
             }
             titleStyle={{
@@ -378,8 +377,15 @@ function AssetDetailsDialog(props: Props) {
             }}
           />
           <Typography className={classes.domain} variant="subtitle1">
-            {balance ? (
+            {balance ? (<>
               <SingleBalance assetCode={asset.getCode()} balance={balance.balance} />
+              <Box className={classes.toolbar}>
+                <VisibilityIconButton
+                  accountId={props.account.accountID}
+                  asset={asset}
+                />
+              </Box>
+            </>
             ) : asset.isNative() ? (
               "stellar.org"
             ) : (

--- a/src/Assets/components/BalanceDetailsListItem.tsx
+++ b/src/Assets/components/BalanceDetailsListItem.tsx
@@ -171,10 +171,12 @@ function BalanceListItem(props: BalanceListItemProps) {
   return (
     <ListItem button={Boolean(props.onClick) as any} className={className} onClick={props.onClick} style={props.style}>
       {props.isEditMode && props.accountId && (
-        <VisibilityIconButton
-          accountId={props.accountId}
-          asset={asset}
-        />
+        <ListItemIcon className={classes.icon} style={{minWidth: "30px", marginRight: "8px" }}>
+          <VisibilityIconButton
+            accountId={props.accountId}
+            asset={asset}
+          />
+        </ListItemIcon>
       )}
       <ListItemIcon className={classes.icon}>
         <Badge badgeContent={props.badgeCount} classes={{ badge: classes.badge }} color="primary">

--- a/src/Assets/components/VisibilityIconButton.tsx
+++ b/src/Assets/components/VisibilityIconButton.tsx
@@ -18,11 +18,6 @@ const useStyles = makeStyles({
       color: "rgba(0, 0, 0, 0.38)"
     }
   },
-  visibilityIconContainer: {
-    marginRight: 8,
-    display: "inline-flex",
-    alignItems: "center"
-  }
 })
 
 interface Props {
@@ -51,7 +46,6 @@ function VisibilityIconButton(props: Props) {
   }
 
   return (
-    <div className={classes.visibilityIconContainer}>
       <IconButton
         size="small"
         onClick={(e) => {
@@ -61,7 +55,6 @@ function VisibilityIconButton(props: Props) {
       >
         {icon}
       </IconButton>
-    </div>
   )
 }
 


### PR DESCRIPTION
Example: USDM (full name is 15 characters)

Solution: moving the fav icon below the balance. Later on there will be another icon buttons here, so it becomes a toolbar for asset actions

![image](https://github.com/user-attachments/assets/72335881-c800-4dc8-9252-764e5424e4ba)

Closes #148 