### PR TITLE
feat: allow copying issuer address on Asset Details page

### DIFF
--- a/src/Generic/components/FormFields.tsx
+++ b/src/Generic/components/FormFields.tsx
@@ -107,7 +107,7 @@ export const ReadOnlyTextfield = React.memo(function ReadOnlyTextfield(props: Re
   const InputProps: InputProps = {
     disableUnderline: disableUnderline === false ? false : true,
     multiline,
-    disabled: true,
+    disabled: false,
     readOnly: true,
     ...props.InputProps
   }


### PR DESCRIPTION
The code was already there, but `onClick` handler wasn't called by browser due to the field being `disabled="true"`

Closes #145 