### PR TITLE
feat: allow to seach assets in Asset Selector

### DIFF
--- a/src/Generic/components/AssetSelector.tsx
+++ b/src/Generic/components/AssetSelector.tsx
@@ -130,7 +130,10 @@ function AssetSelector(props: AssetSelectorProps) {
   const showHidden = showHiddenClicked || hiddenAssetSelected
 
   const [open, setOpen] = React.useState(false)
-  const handleOpen = React.useCallback(() => setOpen(true), [])
+  const handleOpen = React.useCallback(() => {
+    setOpen(true)
+    setSearchFieldValue("")
+  }, [])
   const handleClose = React.useCallback(() => setOpen(false), [])
 
   const handleChange = React.useCallback(
@@ -209,7 +212,7 @@ function AssetSelector(props: AssetSelectorProps) {
         renderValue: () => (props.value ? props.value.getCode() : t("generic.assets.select-an-asset-short"))
       }}
     >
-      {!props.disabled &&
+      {!props.disabled && assets.length > 10 &&
         <MenuItem
           disableRipple
           className={classes.searchField}

--- a/src/Generic/components/FormFields.tsx
+++ b/src/Generic/components/FormFields.tsx
@@ -121,11 +121,11 @@ export const ReadOnlyTextfield = React.memo(function ReadOnlyTextfield(props: Re
   )
 })
 
-export const SearchField = React.memo(function SearchField(props: Omit<OutlinedTextFieldProps, "variant">) {
+export const SearchField = React.memo(function SearchField(props: TextFieldProps) {
   return (
     <TextField
       fullWidth
-      variant="outlined"
+      variant={props.variant || "outlined"}
       {...props}
       InputProps={{
         endAdornment: (


### PR DESCRIPTION
Changed AssetSelector component to show search field inside the select box. Search is shown only if there are more than 10 assets in the list.

Both hidden and visible assets are filtered. Search is done by substring match (e.g. "MTL" matches both "EURMTL" and "MTLRECT")


https://github.com/user-attachments/assets/ae898209-52bb-422e-b725-668b49028d2e

